### PR TITLE
fix `ncurses.h` path in difference OS

### DIFF
--- a/Headers/Dungeon.h
+++ b/Headers/Dungeon.h
@@ -3,7 +3,11 @@
 
 #include <algorithm>
 #include <ctime>
+#ifdef _WIN32
 #include <ncurses/ncurses.h>
+#else
+#include <ncurses.h>
+#endif
 #include <random>
 #include <utility>
 #include <vector>

--- a/Headers/Entity.h
+++ b/Headers/Entity.h
@@ -1,7 +1,11 @@
 #ifndef ENTITY
 #define ENTITY
 
+#ifdef _WIN32
 #include <ncurses/ncurses.h>
+#else
+#include <ncurses.h>
+#endif
 #include <random>
 #include <unordered_map>
 #include <utility>

--- a/Headers/GraphicManager.h
+++ b/Headers/GraphicManager.h
@@ -1,6 +1,10 @@
 #ifndef GRAPHIC
 #define GRAPHIC
+#ifdef _WIN32
 #include <ncurses/ncurses.h>
+#else
+#include <ncurses.h>
+#endif
 
 #include <string>
 


### PR DESCRIPTION
It seems the path for `ncurses.h` on Windows MSYS2 is "ncurses/ncurses.h", but on MacOS and Linux is simply "ncurses.h".