### PR TITLE
Better `check_size` utility

### DIFF
--- a/check_size.cpp
+++ b/check_size.cpp
@@ -26,7 +26,7 @@ int main() {
 
     const auto *const print_row = "Current Rows: ";
     const auto *const print_col = ", Current Columns: ";
-    const auto print_len = static_cast<int>(std::strlen(print_row) + std::strlen(print_row) + 4);
+    const auto print_len = static_cast<int>(std::strlen(print_row) + std::strlen(print_col) + 4);
 
     const auto *const exit = "(Press Q when done)";
     const auto exit_len = static_cast<int>(std::strlen(exit));

--- a/check_size.cpp
+++ b/check_size.cpp
@@ -67,6 +67,10 @@ int main() {
         if (std::toupper(getch()) == 'Q') break;
     }
     endwin();
+#ifdef _WIN32
+    std::system("cls");
+#else
     std::system("clear");
+#endif
     return 0;
 }

--- a/check_size.cpp
+++ b/check_size.cpp
@@ -1,7 +1,11 @@
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
+#ifdef _WIN32
+#include <ncurses/ncurses.h>
+#else
 #include <ncurses.h>
+#endif
 
 // an interactive program helps the user to resize the terminal
 


### PR DESCRIPTION
Now this utility is based on `ncurses`. It will always print the current size of the terminal in the middle of the screen. It is also rewritten so users can interactively adjust the terminal size based on the information on the screen.

**Screenshots**:
<img width="882" alt="Screenshot 2024-04-19 at 04 16 06" src="https://github.com/Seann0425/OOP_Dungeon/assets/116703995/d13265ef-86af-4fd6-a4d9-cfb82d0d5d3f">
<img width="922" alt="Screenshot 2024-04-19 at 04 16 23" src="https://github.com/Seann0425/OOP_Dungeon/assets/116703995/83cc5320-99e7-46e8-bfe2-c23505ce56a1">
<img width="1082" alt="Screenshot 2024-04-19 at 04 16 33" src="https://github.com/Seann0425/OOP_Dungeon/assets/116703995/830fb477-b063-4d76-a911-75885da16006">
